### PR TITLE
Parse and format job content for Laravel jobs

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -346,7 +346,16 @@ abstract class BaseCommand extends Command
         $this->output->writeln('<comment>body:</comment>');
 
         $data = $job->getData();
-        $this->output->writeln("\"$data\"");
+
+        $output = "\"$data\"";
+        if (substr($data, 0, 7) == '{"job":') {
+            $json = json_decode($data, true);
+            if ($json && isset($json['data']['command'])) {
+                $php = unserialize($json['data']['command']);
+                $output = print_r($php, true);
+            }
+        }
+        $this->output->writeln($output);
     }
 
     /**


### PR DESCRIPTION
Small change that parses and formats jobs, when using Laravel.

This change is very specific for Laravel, but it defaults to the old behaviour, for other content types.